### PR TITLE
ci: Add x86 based macOS to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       matrix:
         python-version: ["3.8", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Intel runner
+          - runs-on: macos-13
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* "macos-latest" now uses Apple silicon runners, so use "macos-13" to have access to an x86 based macOS runner.